### PR TITLE
Collapse adjacent =??B? words losslessly

### DIFF
--- a/lib/mail/encodings.rb
+++ b/lib/mail/encodings.rb
@@ -292,7 +292,6 @@ module Mail
 
         if encoding == previous_encoding
           line = results.pop + line
-          line.gsub!(/\?\=\=\?.+?\?[QqBb]\?/m, '')
         end
 
         previous_encoding = encoding

--- a/spec/mail/encodings_spec.rb
+++ b/spec/mail/encodings_spec.rb
@@ -154,6 +154,12 @@ describe Mail::Encodings do
       Mail::Encodings.value_decode(string).should == string
     end
 
+    it "should collapse adjacent words" do
+      string = "=?utf-8?B?0L3QvtCy0YvQuSDRgdC+0YLRgNGD0LTQvdC40Log4oCUINC00L7RgNC+0YQ=?=\n =?utf-8?B?0LXQtdCy?="
+      result = "новый сотрудник — дорофеев"
+      Mail::Encodings.value_decode(string).should == result
+    end
+
     if '1.9'.respond_to?(:force_encoding)
       it "should decode 8bit encoded string" do
         string = "=?8bit?Q?ALPH=C3=89E?="


### PR DESCRIPTION
Commit 227e69e8b9cca6b93b48bf40cb27400980c09c56 seems to be missing from branch `2-5-stable` of degica/basecamp2.  I re-pulled this commit from the freerunningtech fork of this repo, and my `bundle install` was able to pass locally then.
